### PR TITLE
[bilal] Schéma BDD complet — Zone sacrée + Applicative + Média + Permissions

### DIFF
--- a/database/migrations/000_create_database.sql
+++ b/database/migrations/000_create_database.sql
@@ -1,0 +1,22 @@
+-- ============================================================
+-- 000_create_database.sql
+-- Création de la base de données avec encodage UTF-8 obligatoire
+-- (à exécuter en tant que superuser PostgreSQL)
+-- ============================================================
+
+CREATE DATABASE saas_islam
+  ENCODING 'UTF8'
+  LC_COLLATE 'en_US.UTF-8'
+  LC_CTYPE 'en_US.UTF-8'
+  TEMPLATE template0;
+
+-- Créer l'utilisateur applicatif (droits limités)
+CREATE USER app_user WITH PASSWORD 'CHANGE_ME_IN_ENV';
+
+-- Connexion à la base
+\connect saas_islam;
+
+-- Extensions utiles
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";     -- UUIDs automatiques
+CREATE EXTENSION IF NOT EXISTS "unaccent";       -- Recherche sans accents
+CREATE EXTENSION IF NOT EXISTS "pg_trgm";        -- Recherche floue

--- a/database/migrations/001_sacred_zone_quran.sql
+++ b/database/migrations/001_sacred_zone_quran.sql
@@ -1,0 +1,101 @@
+-- ============================================================
+-- 001_sacred_zone_quran.sql
+-- 🔒 ZONE SACRÉE — CORAN
+-- ⚠️ CES TABLES SONT IMMUABLES — AUCUN UPDATE/DELETE AUTORISÉ
+-- ============================================================
+
+-- ── Sourates ──────────────────────────────────────────────
+CREATE TABLE quran_surahs (
+  id              SMALLINT PRIMARY KEY,         -- Numéro sourate (1-114)
+  name_arabic     TEXT NOT NULL,                -- اسم السورة بالعربية
+  name_english    TEXT NOT NULL,                -- Nom translittéré
+  name_french     TEXT NOT NULL,                -- Nom en français
+  revelation_type TEXT NOT NULL                 -- 'meccan' ou 'medinan'
+                  CHECK (revelation_type IN ('meccan', 'medinan')),
+  ayah_count      SMALLINT NOT NULL,            -- Nombre de versets
+  has_bismillah   BOOLEAN NOT NULL DEFAULT TRUE -- FALSE pour At-Tawbah (9)
+);
+
+-- ── Versets ───────────────────────────────────────────────
+CREATE TABLE quran_ayahs (
+  id              INTEGER PRIMARY KEY,           -- ID unique global
+  surah_number    SMALLINT NOT NULL REFERENCES quran_surahs(id),
+  ayah_number     SMALLINT NOT NULL,             -- Numéro dans la sourate
+  text_uthmani    TEXT NOT NULL,                 -- Texte arabe (Mushaf Hafs)
+  text_simple     TEXT NOT NULL,                 -- Texte arabe simplifié (sans tashkeel)
+  juz             SMALLINT NOT NULL,             -- Juz (1-30)
+  hizb            SMALLINT NOT NULL,             -- Hizb
+  rub_el_hizb     SMALLINT NOT NULL,             -- Rub' el-Hizb
+  sajdah          BOOLEAN NOT NULL DEFAULT FALSE,-- Verset de prosternation
+  UNIQUE (surah_number, ayah_number)
+);
+
+-- ── Traductions ───────────────────────────────────────────
+CREATE TABLE quran_translations (
+  id              SERIAL PRIMARY KEY,
+  ayah_id         INTEGER NOT NULL REFERENCES quran_ayahs(id),
+  language_code   VARCHAR(5) NOT NULL,           -- 'fr', 'en', 'de', etc.
+  translator      TEXT NOT NULL,                 -- Nom du traducteur
+  text            TEXT NOT NULL,                 -- Texte traduit
+  UNIQUE (ayah_id, language_code, translator)
+);
+
+-- ── Tafsirs ──────────────────────────────────────────────
+CREATE TABLE quran_tafsirs (
+  id              SERIAL PRIMARY KEY,
+  ayah_id         INTEGER NOT NULL REFERENCES quran_ayahs(id),
+  scholar         TEXT NOT NULL,                 -- 'ibn_kathir', 'saadi', 'tabari'
+  language_code   VARCHAR(5) NOT NULL,
+  text            TEXT NOT NULL,
+  UNIQUE (ayah_id, scholar, language_code)
+);
+
+-- ── Traduction mot à mot ──────────────────────────────────
+CREATE TABLE quran_word_by_word (
+  id              SERIAL PRIMARY KEY,
+  ayah_id         INTEGER NOT NULL REFERENCES quran_ayahs(id),
+  word_position   SMALLINT NOT NULL,             -- Position du mot dans le verset
+  text_arabic     TEXT NOT NULL,                 -- Mot en arabe
+  transliteration TEXT,                          -- Translittération
+  translation_en  TEXT,                          -- Traduction anglaise du mot
+  translation_fr  TEXT,                          -- Traduction française du mot
+  UNIQUE (ayah_id, word_position)
+);
+
+-- ── Règles de Tajweed ────────────────────────────────────
+CREATE TABLE quran_tajweed_rules (
+  id              SERIAL PRIMARY KEY,
+  ayah_id         INTEGER NOT NULL REFERENCES quran_ayahs(id),
+  word_position   SMALLINT NOT NULL,
+  char_position   SMALLINT NOT NULL,
+  rule_name       TEXT NOT NULL,                 -- Ex : 'ghunnah', 'madd', 'idgham'
+  color_code      VARCHAR(7)                     -- Code couleur HEX pour affichage
+);
+
+-- ── Récitateurs ──────────────────────────────────────────
+CREATE TABLE reciters (
+  id              SERIAL PRIMARY KEY,
+  name_arabic     TEXT NOT NULL,
+  name_english    TEXT NOT NULL,
+  style           TEXT NOT NULL                  -- 'murattal', 'mujawwad', 'muallim'
+                  CHECK (style IN ('murattal', 'mujawwad', 'muallim'))
+);
+
+-- ── Récitations audio ────────────────────────────────────
+CREATE TABLE audio_recitations (
+  id              SERIAL PRIMARY KEY,
+  ayah_id         INTEGER NOT NULL REFERENCES quran_ayahs(id),
+  reciter_id      INTEGER NOT NULL REFERENCES reciters(id),
+  audio_url       TEXT NOT NULL,                 -- URL Cloudflare R2
+  duration_ms     INTEGER,                       -- Durée en millisecondes
+  UNIQUE (ayah_id, reciter_id)
+);
+
+COMMENT ON TABLE quran_surahs IS '🔒 ZONE SACRÉE — LECTURE SEULE';
+COMMENT ON TABLE quran_ayahs IS '🔒 ZONE SACRÉE — LECTURE SEULE';
+COMMENT ON TABLE quran_translations IS '🔒 ZONE SACRÉE — LECTURE SEULE';
+COMMENT ON TABLE quran_tafsirs IS '🔒 ZONE SACRÉE — LECTURE SEULE';
+COMMENT ON TABLE quran_word_by_word IS '🔒 ZONE SACRÉE — LECTURE SEULE';
+COMMENT ON TABLE quran_tajweed_rules IS '🔒 ZONE SACRÉE — LECTURE SEULE';
+COMMENT ON TABLE reciters IS '🔒 ZONE SACRÉE — LECTURE SEULE';
+COMMENT ON TABLE audio_recitations IS '🔒 ZONE SACRÉE — LECTURE SEULE';

--- a/database/migrations/002_sacred_zone_hadiths.sql
+++ b/database/migrations/002_sacred_zone_hadiths.sql
@@ -1,0 +1,67 @@
+-- ============================================================
+-- 002_sacred_zone_hadiths.sql
+-- 🔒 ZONE SACRÉE — HADITHS
+-- ⚠️ CES TABLES SONT IMMUABLES — AUCUN UPDATE/DELETE AUTORISÉ
+-- ============================================================
+
+-- ── Collections de hadiths ────────────────────────────────
+CREATE TABLE hadith_collections (
+  id              SERIAL PRIMARY KEY,
+  name_arabic     TEXT NOT NULL,                 -- اسم المجموعة
+  name_english    TEXT NOT NULL,                 -- Sahih al-Bukhari, etc.
+  name_french     TEXT NOT NULL,
+  author          TEXT NOT NULL,                 -- Imam Al-Bukhari, etc.
+  total_hadiths   INTEGER NOT NULL
+);
+
+-- ── Hadiths ──────────────────────────────────────────────
+CREATE TABLE hadiths (
+  id              SERIAL PRIMARY KEY,
+  collection_id   INTEGER NOT NULL REFERENCES hadith_collections(id),
+  hadith_number   TEXT NOT NULL,                 -- Numéro dans la collection
+  chapter_number  INTEGER,
+  chapter_title   TEXT,
+  text_arabic     TEXT NOT NULL,                 -- Texte arabe complet (matn)
+  narrator_chain  TEXT,                          -- Chaîne de transmission (isnad)
+  UNIQUE (collection_id, hadith_number)
+);
+
+-- ── Traductions des hadiths ───────────────────────────────
+CREATE TABLE hadith_translations (
+  id              SERIAL PRIMARY KEY,
+  hadith_id       INTEGER NOT NULL REFERENCES hadiths(id),
+  language_code   VARCHAR(5) NOT NULL,
+  text            TEXT NOT NULL,
+  UNIQUE (hadith_id, language_code)
+);
+
+-- ── Classifications ───────────────────────────────────────
+CREATE TABLE hadith_gradings (
+  id              SERIAL PRIMARY KEY,
+  hadith_id       INTEGER NOT NULL REFERENCES hadiths(id),
+  scholar         TEXT NOT NULL,                 -- 'al-albani', 'ibn-hajar', etc.
+  grade           TEXT NOT NULL                  -- 'sahih', 'hassan', 'daif', etc.
+                  CHECK (grade IN ('sahih', 'hassan', 'daif', 'mawdu', 'hasan_sahih', 'sahih_li_ghayrihi', 'hasan_li_ghayrihi')),
+  notes           TEXT,
+  UNIQUE (hadith_id, scholar)
+);
+
+-- ── Catégories thématiques ────────────────────────────────
+CREATE TABLE hadith_categories (
+  id              SERIAL PRIMARY KEY,
+  name_arabic     TEXT NOT NULL,
+  name_french     TEXT NOT NULL,
+  name_english    TEXT NOT NULL
+);
+
+CREATE TABLE hadith_category_links (
+  hadith_id       INTEGER NOT NULL REFERENCES hadiths(id),
+  category_id     INTEGER NOT NULL REFERENCES hadith_categories(id),
+  PRIMARY KEY (hadith_id, category_id)
+);
+
+COMMENT ON TABLE hadith_collections IS '🔒 ZONE SACRÉE — LECTURE SEULE';
+COMMENT ON TABLE hadiths IS '🔒 ZONE SACRÉE — LECTURE SEULE';
+COMMENT ON TABLE hadith_translations IS '🔒 ZONE SACRÉE — LECTURE SEULE';
+COMMENT ON TABLE hadith_gradings IS '🔒 ZONE SACRÉE — LECTURE SEULE';
+COMMENT ON TABLE hadith_categories IS '🔒 ZONE SACRÉE — LECTURE SEULE';

--- a/database/migrations/003_sacred_zone_islamic_sciences.sql
+++ b/database/migrations/003_sacred_zone_islamic_sciences.sql
@@ -1,0 +1,141 @@
+-- ============================================================
+-- 003_sacred_zone_islamic_sciences.sql
+-- 🔒 ZONE SACRÉE — SCIENCES ISLAMIQUES
+-- Duas, Noms d'Allah, Mutun, Seerah, Calendrier Hijri
+-- ⚠️ CES TABLES SONT IMMUABLES — AUCUN UPDATE/DELETE AUTORISÉ
+-- ============================================================
+
+-- ── Invocations (Duas) ───────────────────────────────────
+CREATE TABLE dua_categories (
+  id              SERIAL PRIMARY KEY,
+  name_arabic     TEXT NOT NULL,
+  name_french     TEXT NOT NULL,
+  name_english    TEXT NOT NULL
+);
+
+CREATE TABLE duas (
+  id              SERIAL PRIMARY KEY,
+  category_id     INTEGER REFERENCES dua_categories(id),
+  title_arabic    TEXT NOT NULL,
+  title_french    TEXT NOT NULL,
+  text_arabic     TEXT NOT NULL,                 -- Texte arabe de la dua
+  transliteration TEXT,                          -- Translittération phonétique
+  translation_fr  TEXT NOT NULL,
+  translation_en  TEXT,
+  source          TEXT,                          -- Référence (Coran, hadith...)
+  occasion        TEXT                           -- Quand la réciter
+);
+
+-- ── 99 Noms d'Allah ──────────────────────────────────────
+CREATE TABLE allah_names (
+  id              SMALLINT PRIMARY KEY,          -- 1 à 99
+  name_arabic     TEXT NOT NULL,                 -- الاسم بالعربية
+  transliteration TEXT NOT NULL,                 -- Al-Rahman, etc.
+  meaning_fr      TEXT NOT NULL,
+  meaning_en      TEXT NOT NULL,
+  explanation_fr  TEXT,                          -- Explication approfondie
+  quran_reference TEXT                           -- Sourate + verset si applicable
+);
+
+-- ── Mutun (textes de mémorisation) ───────────────────────
+CREATE TABLE mutun_categories (
+  id              SERIAL PRIMARY KEY,
+  name_arabic     TEXT NOT NULL,
+  name_french     TEXT NOT NULL,                 -- 'Grammaire', 'Fiqh', 'Aqida'...
+  name_english    TEXT NOT NULL
+);
+
+CREATE TABLE mutun (
+  id              SERIAL PRIMARY KEY,
+  category_id     INTEGER NOT NULL REFERENCES mutun_categories(id),
+  title_arabic    TEXT NOT NULL,
+  title_french    TEXT NOT NULL,
+  author          TEXT NOT NULL,                 -- Ibn Ajurrum, Ibn Malik, etc.
+  era             TEXT,                          -- Époque de l'auteur
+  total_lines     INTEGER,
+  difficulty      SMALLINT                       -- 1 (facile) à 5 (avancé)
+                  CHECK (difficulty BETWEEN 1 AND 5)
+);
+
+CREATE TABLE mutun_lines (
+  id              SERIAL PRIMARY KEY,
+  matn_id         INTEGER NOT NULL REFERENCES mutun(id),
+  line_number     INTEGER NOT NULL,
+  text_arabic     TEXT NOT NULL,                 -- Texte arabe du vers
+  translation_fr  TEXT,
+  notes           TEXT,
+  UNIQUE (matn_id, line_number)
+);
+
+-- ── Savants ──────────────────────────────────────────────
+CREATE TABLE scholars (
+  id              SERIAL PRIMARY KEY,
+  name_arabic     TEXT NOT NULL,
+  name_french     TEXT NOT NULL,
+  birth_year_hijri SMALLINT,
+  death_year_hijri SMALLINT,
+  specialization  TEXT[],                        -- ['fiqh', 'hadith', 'tafsir', ...]
+  biography_fr    TEXT,
+  biography_ar    TEXT
+);
+
+-- ── Prophètes ────────────────────────────────────────────
+CREATE TABLE prophets (
+  id              SERIAL PRIMARY KEY,
+  name_arabic     TEXT NOT NULL,
+  name_french     TEXT NOT NULL,
+  order_mentioned SMALLINT,                      -- Ordre de mention dans le Coran
+  quran_mentions  INTEGER,                       -- Nombre de mentions dans le Coran
+  story_fr        TEXT
+);
+
+-- ── Calendrier islamique ─────────────────────────────────
+CREATE TABLE islamic_calendar (
+  id              SERIAL PRIMARY KEY,
+  event_name_ar   TEXT NOT NULL,
+  event_name_fr   TEXT NOT NULL,
+  hijri_month     SMALLINT NOT NULL CHECK (hijri_month BETWEEN 1 AND 12),
+  hijri_day       SMALLINT NOT NULL CHECK (hijri_day BETWEEN 1 AND 30),
+  description_fr  TEXT,
+  is_recurring    BOOLEAN NOT NULL DEFAULT TRUE  -- Événement annuel récurrent
+);
+
+-- ── Livres de référence ───────────────────────────────────
+CREATE TABLE reference_books (
+  id              SERIAL PRIMARY KEY,
+  title_arabic    TEXT NOT NULL,
+  title_french    TEXT NOT NULL,
+  author_id       INTEGER REFERENCES scholars(id),
+  domain          TEXT NOT NULL                  -- 'fiqh', 'aqida', 'tafsir', 'hadith', 'nahw', 'seerah'
+                  CHECK (domain IN ('fiqh', 'aqida', 'tafsir', 'hadith', 'nahw', 'seerah', 'tasawwuf', 'usul_al_fiqh', 'other')),
+  difficulty      SMALLINT CHECK (difficulty BETWEEN 1 AND 5),
+  description_fr  TEXT
+);
+
+CREATE TABLE book_chapters (
+  id              SERIAL PRIMARY KEY,
+  book_id         INTEGER NOT NULL REFERENCES reference_books(id),
+  chapter_number  INTEGER NOT NULL,
+  title_arabic    TEXT,
+  title_french    TEXT,
+  UNIQUE (book_id, chapter_number)
+);
+
+CREATE TABLE book_content (
+  id              SERIAL PRIMARY KEY,
+  chapter_id      INTEGER NOT NULL REFERENCES book_chapters(id),
+  paragraph_number INTEGER NOT NULL,
+  text_arabic     TEXT NOT NULL,
+  translation_fr  TEXT,
+  UNIQUE (chapter_id, paragraph_number)
+);
+
+COMMENT ON TABLE duas IS '🔒 ZONE SACRÉE — LECTURE SEULE';
+COMMENT ON TABLE allah_names IS '🔒 ZONE SACRÉE — LECTURE SEULE';
+COMMENT ON TABLE mutun IS '🔒 ZONE SACRÉE — LECTURE SEULE';
+COMMENT ON TABLE mutun_lines IS '🔒 ZONE SACRÉE — LECTURE SEULE';
+COMMENT ON TABLE scholars IS '🔒 ZONE SACRÉE — LECTURE SEULE';
+COMMENT ON TABLE prophets IS '🔒 ZONE SACRÉE — LECTURE SEULE';
+COMMENT ON TABLE islamic_calendar IS '🔒 ZONE SACRÉE — LECTURE SEULE';
+COMMENT ON TABLE reference_books IS '🔒 ZONE SACRÉE — LECTURE SEULE';
+COMMENT ON TABLE book_content IS '🔒 ZONE SACRÉE — LECTURE SEULE';

--- a/database/migrations/004_applicative_zone_users.sql
+++ b/database/migrations/004_applicative_zone_users.sql
@@ -1,0 +1,107 @@
+-- ============================================================
+-- 004_applicative_zone_users.sql
+-- 🔓 ZONE APPLICATIVE — UTILISATEURS & AUTH
+-- Ces tables peuvent être lues ET modifiées par app_user
+-- ============================================================
+
+-- ── Utilisateurs ─────────────────────────────────────────
+CREATE TABLE users (
+  id              UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  email           TEXT UNIQUE NOT NULL,
+  username        TEXT UNIQUE,
+  display_name    TEXT,
+  avatar_url      TEXT,
+  gender          TEXT CHECK (gender IN ('male', 'female', 'not_specified')) DEFAULT 'not_specified',
+  country_code    VARCHAR(2),                    -- Code pays ISO
+  language_code   VARCHAR(5) DEFAULT 'fr',       -- Langue préférée
+  role            TEXT NOT NULL DEFAULT 'user'
+                  CHECK (role IN ('user', 'moderator', 'admin')),
+  is_verified     BOOLEAN DEFAULT FALSE,
+  is_active       BOOLEAN DEFAULT TRUE,
+  created_at      TIMESTAMPTZ DEFAULT NOW(),
+  updated_at      TIMESTAMPTZ DEFAULT NOW(),
+  last_seen_at    TIMESTAMPTZ
+);
+
+-- ── Paramètres utilisateur ───────────────────────────────
+CREATE TABLE user_settings (
+  user_id                   UUID PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+  -- Coran
+  quran_font_size           SMALLINT DEFAULT 22 CHECK (quran_font_size BETWEEN 16 AND 48),
+  quran_translation_lang    VARCHAR(5) DEFAULT 'fr',
+  quran_reciter_id          INTEGER REFERENCES reciters(id),
+  show_transliteration      BOOLEAN DEFAULT FALSE,
+  show_translation          BOOLEAN DEFAULT TRUE,
+  show_tafsir               BOOLEAN DEFAULT FALSE,
+  -- Prière
+  prayer_method             TEXT DEFAULT 'MWL'   -- MWL, ISNA, Egypt, Makkah, Karachi...
+                            CHECK (prayer_method IN ('MWL', 'ISNA', 'Egypt', 'Makkah', 'Karachi', 'Tehran', 'Jafari')),
+  prayer_asr_method         TEXT DEFAULT 'standard'
+                            CHECK (prayer_asr_method IN ('standard', 'hanafi')),
+  -- UI
+  theme                     TEXT DEFAULT 'light' CHECK (theme IN ('light', 'dark', 'auto')),
+  -- Notifications
+  notif_fajr               BOOLEAN DEFAULT TRUE,
+  notif_dhuhr              BOOLEAN DEFAULT TRUE,
+  notif_asr                BOOLEAN DEFAULT TRUE,
+  notif_maghrib            BOOLEAN DEFAULT TRUE,
+  notif_isha               BOOLEAN DEFAULT TRUE,
+  notif_daily_ayah         BOOLEAN DEFAULT TRUE,
+  notif_daily_hadith       BOOLEAN DEFAULT TRUE,
+  updated_at               TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- ── Marque-pages ─────────────────────────────────────────
+CREATE TABLE user_bookmarks (
+  id              UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  user_id         UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  content_type    TEXT NOT NULL CHECK (content_type IN ('ayah', 'hadith', 'dua', 'matn_line')),
+  content_id      INTEGER NOT NULL,              -- ID dans la table correspondante
+  note            TEXT,
+  created_at      TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE (user_id, content_type, content_id)
+);
+
+-- ── Favoris ───────────────────────────────────────────────
+CREATE TABLE user_favorites (
+  id              UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  user_id         UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  content_type    TEXT NOT NULL CHECK (content_type IN ('ayah', 'hadith', 'dua', 'video', 'scholar')),
+  content_id      INTEGER NOT NULL,
+  created_at      TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE (user_id, content_type, content_id)
+);
+
+-- ── Notes personnelles ───────────────────────────────────
+CREATE TABLE user_notes (
+  id              UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  user_id         UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  content_type    TEXT NOT NULL,
+  content_id      INTEGER NOT NULL,
+  note_text       TEXT NOT NULL,
+  created_at      TIMESTAMPTZ DEFAULT NOW(),
+  updated_at      TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- ── Abonnements ──────────────────────────────────────────
+CREATE TABLE subscriptions (
+  id              UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  user_id         UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  plan            TEXT NOT NULL CHECK (plan IN ('free', 'basic', 'premium')),
+  status          TEXT NOT NULL CHECK (status IN ('active', 'cancelled', 'expired', 'trial')),
+  started_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  expires_at      TIMESTAMPTZ,
+  stripe_sub_id   TEXT                           -- ID Stripe (si applicable)
+);
+
+-- ── Paiements ────────────────────────────────────────────
+CREATE TABLE payments (
+  id              UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  user_id         UUID NOT NULL REFERENCES users(id),
+  amount_cents    INTEGER NOT NULL,
+  currency        VARCHAR(3) DEFAULT 'EUR',
+  status          TEXT NOT NULL CHECK (status IN ('pending', 'succeeded', 'failed', 'refunded')),
+  provider        TEXT DEFAULT 'stripe',
+  provider_ref    TEXT,                          -- ID transaction externe
+  created_at      TIMESTAMPTZ DEFAULT NOW()
+);

--- a/database/migrations/005_applicative_zone_progress.sql
+++ b/database/migrations/005_applicative_zone_progress.sql
@@ -1,0 +1,78 @@
+-- ============================================================
+-- 005_applicative_zone_progress.sql
+-- 🔓 ZONE APPLICATIVE — PROGRESSION & MÉMORISATION
+-- ============================================================
+
+-- ── Progression de lecture Coran ─────────────────────────
+CREATE TABLE user_reading_progress (
+  id              UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  user_id         UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  last_surah      SMALLINT NOT NULL REFERENCES quran_surahs(id),
+  last_ayah       SMALLINT NOT NULL,
+  total_ayahs_read INTEGER DEFAULT 0,
+  updated_at      TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE (user_id)
+);
+
+-- ── Mémorisation du Coran ────────────────────────────────
+CREATE TABLE user_quran_memorization (
+  id              UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  user_id         UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  ayah_id         INTEGER NOT NULL REFERENCES quran_ayahs(id),
+  status          TEXT NOT NULL DEFAULT 'not_started'
+                  CHECK (status IN ('not_started', 'in_progress', 'memorized', 'review_needed')),
+  strength        SMALLINT DEFAULT 0 CHECK (strength BETWEEN 0 AND 5),  -- Force de mémorisation
+  next_review_at  TIMESTAMPTZ,               -- Prochaine révision (SRS)
+  review_count    INTEGER DEFAULT 0,
+  last_reviewed_at TIMESTAMPTZ,
+  UNIQUE (user_id, ayah_id)
+);
+
+-- ── Mémorisation des Mutun ───────────────────────────────
+CREATE TABLE user_mutun_memorization (
+  id              UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  user_id         UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  matn_line_id    INTEGER NOT NULL REFERENCES mutun_lines(id),
+  status          TEXT NOT NULL DEFAULT 'not_started'
+                  CHECK (status IN ('not_started', 'in_progress', 'memorized', 'review_needed')),
+  strength        SMALLINT DEFAULT 0 CHECK (strength BETWEEN 0 AND 5),
+  next_review_at  TIMESTAMPTZ,
+  review_count    INTEGER DEFAULT 0,
+  last_reviewed_at TIMESTAMPTZ,
+  UNIQUE (user_id, matn_line_id)
+);
+
+-- ── Streaks (jours consécutifs) ───────────────────────────
+CREATE TABLE user_streaks (
+  id              UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  user_id         UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  activity_type   TEXT NOT NULL CHECK (activity_type IN ('reading', 'memorization', 'academy')),
+  current_streak  INTEGER DEFAULT 0,
+  longest_streak  INTEGER DEFAULT 0,
+  last_activity_date DATE,
+  UNIQUE (user_id, activity_type)
+);
+
+-- ── Badges islamiques ────────────────────────────────────
+CREATE TABLE badges (
+  id              SERIAL PRIMARY KEY,
+  name_fr         TEXT NOT NULL,
+  description_fr  TEXT NOT NULL,
+  icon_url        TEXT,
+  requirement     TEXT NOT NULL                  -- Description de la condition
+);
+
+CREATE TABLE user_badges (
+  user_id         UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  badge_id        INTEGER NOT NULL REFERENCES badges(id),
+  earned_at       TIMESTAMPTZ DEFAULT NOW(),
+  PRIMARY KEY (user_id, badge_id)
+);
+
+-- ── Données initiales : badges
+INSERT INTO badges (name_fr, description_fr, requirement) VALUES
+  ('Premier verset', 'Premier verset mémorisé', 'Mémoriser 1 verset'),
+  ('Juz Amma', 'Juz 30 mémorisé', 'Mémoriser les 37 sourates du 30ème Juz'),
+  ('Al-Fatiha', 'Sourate Al-Fatiha mémorisée', 'Mémoriser Al-Fatiha'),
+  ('Lecteur assidu', '7 jours consécutifs de lecture', 'Streak de lecture 7 jours'),
+  ('Mémorisateur', 'Première mémorisation complète d''une sourate', 'Mémoriser une sourate entière');

--- a/database/migrations/006_applicative_zone_social_academy.sql
+++ b/database/migrations/006_applicative_zone_social_academy.sql
@@ -1,0 +1,133 @@
+-- ============================================================
+-- 006_applicative_zone_social_academy.sql
+-- 🔓 ZONE APPLICATIVE — SOCIAL HALAL & ACADÉMIE
+-- ============================================================
+
+-- ════════════════════════════════════════════════
+-- SOCIAL HALAL
+-- ════════════════════════════════════════════════
+
+-- ── Relations (abonnements entre utilisateurs) ───────────
+CREATE TABLE social_follows (
+  follower_id     UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  following_id    UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  created_at      TIMESTAMPTZ DEFAULT NOW(),
+  PRIMARY KEY (follower_id, following_id),
+  CHECK (follower_id <> following_id)
+);
+
+-- ── Posts ─────────────────────────────────────────────────
+CREATE TABLE social_posts (
+  id              UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  author_id       UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  content_type    TEXT NOT NULL
+                  CHECK (content_type IN ('text', 'ayah_share', 'hadith_share', 'memorization', 'video', 'audio')),
+  caption         TEXT,
+  text_content    TEXT,                          -- Pour les posts texte
+  media_url       TEXT,                          -- URL vidéo/audio sur R2
+  -- Référence optionnelle au contenu religieux partagé
+  ref_ayah_id     INTEGER REFERENCES quran_ayahs(id),
+  ref_hadith_id   INTEGER REFERENCES hadiths(id),
+  is_published    BOOLEAN DEFAULT TRUE,
+  is_moderated    BOOLEAN DEFAULT FALSE,         -- Vérifié par un modérateur
+  moderation_flag TEXT,                          -- Raison si signalé
+  views_count     INTEGER DEFAULT 0,
+  created_at      TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- ── Commentaires ─────────────────────────────────────────
+CREATE TABLE social_comments (
+  id              UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  post_id         UUID NOT NULL REFERENCES social_posts(id) ON DELETE CASCADE,
+  author_id       UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  text            TEXT NOT NULL,
+  is_hidden       BOOLEAN DEFAULT FALSE,
+  created_at      TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- ── Likes / Réactions (halal — pas de "like" vide) ───────
+CREATE TABLE social_reactions (
+  post_id         UUID NOT NULL REFERENCES social_posts(id) ON DELETE CASCADE,
+  user_id         UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  reaction        TEXT NOT NULL
+                  CHECK (reaction IN ('mashallah', 'barakallah', 'ameen', 'jazakallah')),
+  created_at      TIMESTAMPTZ DEFAULT NOW(),
+  PRIMARY KEY (post_id, user_id)
+);
+
+-- ── Signalements ─────────────────────────────────────────
+CREATE TABLE social_reports (
+  id              UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  reporter_id     UUID NOT NULL REFERENCES users(id),
+  post_id         UUID REFERENCES social_posts(id),
+  comment_id      UUID REFERENCES social_comments(id),
+  reason          TEXT NOT NULL
+                  CHECK (reason IN ('haram_content', 'spam', 'misinformation', 'inappropriate', 'other')),
+  details         TEXT,
+  resolved        BOOLEAN DEFAULT FALSE,
+  created_at      TIMESTAMPTZ DEFAULT NOW()
+);
+
+
+-- ════════════════════════════════════════════════
+-- ACADÉMIE ISLAMIQUE
+-- ════════════════════════════════════════════════
+
+-- ── Cours ─────────────────────────────────────────────────
+CREATE TABLE academy_courses (
+  id              SERIAL PRIMARY KEY,
+  title_fr        TEXT NOT NULL,
+  title_ar        TEXT,
+  description_fr  TEXT,
+  domain          TEXT NOT NULL
+                  CHECK (domain IN ('fiqh', 'aqida', 'tafsir', 'hadith', 'arabic', 'seerah', 'other')),
+  level           TEXT NOT NULL CHECK (level IN ('beginner', 'intermediate', 'advanced')),
+  instructor_id   UUID REFERENCES users(id),
+  is_published    BOOLEAN DEFAULT FALSE,
+  thumbnail_url   TEXT,
+  created_at      TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- ── Leçons ───────────────────────────────────────────────
+CREATE TABLE academy_lessons (
+  id              SERIAL PRIMARY KEY,
+  course_id       INTEGER NOT NULL REFERENCES academy_courses(id) ON DELETE CASCADE,
+  lesson_number   SMALLINT NOT NULL,
+  title_fr        TEXT NOT NULL,
+  content_fr      TEXT,
+  video_url       TEXT,
+  duration_min    SMALLINT,
+  UNIQUE (course_id, lesson_number)
+);
+
+-- ── Inscriptions ─────────────────────────────────────────
+CREATE TABLE academy_enrollments (
+  id              UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  user_id         UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  course_id       INTEGER NOT NULL REFERENCES academy_courses(id),
+  enrolled_at     TIMESTAMPTZ DEFAULT NOW(),
+  completed_at    TIMESTAMPTZ,
+  UNIQUE (user_id, course_id)
+);
+
+-- ── Progression dans les cours ───────────────────────────
+CREATE TABLE academy_lesson_progress (
+  user_id         UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  lesson_id       INTEGER NOT NULL REFERENCES academy_lessons(id),
+  completed       BOOLEAN DEFAULT FALSE,
+  completed_at    TIMESTAMPTZ,
+  PRIMARY KEY (user_id, lesson_id)
+);
+
+-- ── Devoirs ──────────────────────────────────────────────
+CREATE TABLE academy_assignments (
+  id              UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  user_id         UUID NOT NULL REFERENCES users(id),
+  lesson_id       INTEGER NOT NULL REFERENCES academy_lessons(id),
+  submission_text TEXT,
+  submission_url  TEXT,
+  submitted_at    TIMESTAMPTZ DEFAULT NOW(),
+  grade           SMALLINT CHECK (grade BETWEEN 0 AND 100),
+  feedback        TEXT,
+  graded_at       TIMESTAMPTZ
+);

--- a/database/migrations/007_media_zone.sql
+++ b/database/migrations/007_media_zone.sql
@@ -1,0 +1,78 @@
+-- ============================================================
+-- 007_media_zone.sql
+-- 🎬 ZONE MÉDIA — Vidéos, Playlists YouTube, Traductions
+-- Gérée par les admins uniquement
+-- ============================================================
+
+-- ── Chaînes YouTube de savants ───────────────────────────
+CREATE TABLE youtube_channels (
+  id              SERIAL PRIMARY KEY,
+  channel_id      TEXT UNIQUE NOT NULL,          -- ID YouTube (ex: UCxxxxxxx)
+  channel_name    TEXT NOT NULL,
+  scholar_id      INTEGER REFERENCES scholars(id),
+  language        VARCHAR(5) DEFAULT 'ar',
+  is_active       BOOLEAN DEFAULT TRUE,
+  last_scraped_at TIMESTAMPTZ
+);
+
+-- ── Playlists YouTube ────────────────────────────────────
+CREATE TABLE youtube_playlists (
+  id              SERIAL PRIMARY KEY,
+  channel_id      INTEGER REFERENCES youtube_channels(id),
+  playlist_id     TEXT UNIQUE NOT NULL,          -- ID YouTube
+  title           TEXT NOT NULL,
+  description     TEXT,
+  video_count     INTEGER DEFAULT 0,
+  domain          TEXT CHECK (domain IN ('tafsir', 'hadith', 'fiqh', 'aqida', 'arabic', 'seerah', 'other')),
+  last_synced_at  TIMESTAMPTZ
+);
+
+-- ── Vidéos YouTube indexées ──────────────────────────────
+CREATE TABLE youtube_videos (
+  id              SERIAL PRIMARY KEY,
+  playlist_id     INTEGER REFERENCES youtube_playlists(id),
+  youtube_id      TEXT UNIQUE NOT NULL,
+  title           TEXT NOT NULL,
+  description     TEXT,
+  duration_sec    INTEGER,
+  published_at    TIMESTAMPTZ,
+  thumbnail_url   TEXT,
+  language        VARCHAR(5) DEFAULT 'ar',
+  is_downloaded   BOOLEAN DEFAULT FALSE,
+  local_path      TEXT,                          -- Chemin si téléchargé
+  scraped_at      TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- ── Vidéos traduites ─────────────────────────────────────
+CREATE TABLE translated_videos (
+  id              SERIAL PRIMARY KEY,
+  source_video_id INTEGER NOT NULL REFERENCES youtube_videos(id),
+  target_language VARCHAR(5) NOT NULL,           -- 'fr', 'en', etc.
+  transcript_ar   TEXT,                          -- Transcription arabe (Whisper)
+  translation_text TEXT,                         -- Traduction générée
+  subtitle_url    TEXT,                          -- URL fichier .srt / .vtt
+  is_verified     BOOLEAN DEFAULT FALSE,         -- Relu par un humain ?
+  verified_by     UUID REFERENCES users(id),
+  verified_at     TIMESTAMPTZ,
+  created_at      TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE (source_video_id, target_language)
+);
+
+-- ── Vidéos (contenu propriétaire) ────────────────────────
+CREATE TABLE videos (
+  id              SERIAL PRIMARY KEY,
+  title_fr        TEXT NOT NULL,
+  title_ar        TEXT,
+  description_fr  TEXT,
+  content_type    TEXT NOT NULL
+                  CHECK (content_type IN ('course', 'conference', 'recitation', 'reminder', 'clip')),
+  domain          TEXT CHECK (domain IN ('tafsir', 'hadith', 'fiqh', 'aqida', 'arabic', 'seerah', 'quran', 'other')),
+  video_url       TEXT NOT NULL,                 -- Cloudflare R2
+  thumbnail_url   TEXT,
+  duration_sec    INTEGER,
+  language        VARCHAR(5) DEFAULT 'fr',
+  scholar_id      INTEGER REFERENCES scholars(id),
+  is_published    BOOLEAN DEFAULT FALSE,
+  views_count     INTEGER DEFAULT 0,
+  created_at      TIMESTAMPTZ DEFAULT NOW()
+);

--- a/database/migrations/008_permissions.sql
+++ b/database/migrations/008_permissions.sql
@@ -1,0 +1,143 @@
+-- ============================================================
+-- 008_permissions.sql
+-- 🔒 CONFIGURATION DES DROITS SQL
+-- app_user = SELECT UNIQUEMENT sur la zone sacrée
+-- app_user = SELECT / INSERT / UPDATE / DELETE sur la zone applicative
+-- ============================================================
+
+-- ════════════════════════════════════════════════
+-- 🔒 ZONE SACRÉE — SELECT UNIQUEMENT
+-- ════════════════════════════════════════════════
+
+-- Retirer TOUS les droits sur les tables sacrées
+REVOKE ALL PRIVILEGES ON TABLE quran_surahs FROM app_user;
+REVOKE ALL PRIVILEGES ON TABLE quran_ayahs FROM app_user;
+REVOKE ALL PRIVILEGES ON TABLE quran_translations FROM app_user;
+REVOKE ALL PRIVILEGES ON TABLE quran_tafsirs FROM app_user;
+REVOKE ALL PRIVILEGES ON TABLE quran_word_by_word FROM app_user;
+REVOKE ALL PRIVILEGES ON TABLE quran_tajweed_rules FROM app_user;
+REVOKE ALL PRIVILEGES ON TABLE audio_recitations FROM app_user;
+REVOKE ALL PRIVILEGES ON TABLE reciters FROM app_user;
+REVOKE ALL PRIVILEGES ON TABLE hadith_collections FROM app_user;
+REVOKE ALL PRIVILEGES ON TABLE hadiths FROM app_user;
+REVOKE ALL PRIVILEGES ON TABLE hadith_translations FROM app_user;
+REVOKE ALL PRIVILEGES ON TABLE hadith_gradings FROM app_user;
+REVOKE ALL PRIVILEGES ON TABLE hadith_categories FROM app_user;
+REVOKE ALL PRIVILEGES ON TABLE hadith_category_links FROM app_user;
+REVOKE ALL PRIVILEGES ON TABLE dua_categories FROM app_user;
+REVOKE ALL PRIVILEGES ON TABLE duas FROM app_user;
+REVOKE ALL PRIVILEGES ON TABLE allah_names FROM app_user;
+REVOKE ALL PRIVILEGES ON TABLE mutun_categories FROM app_user;
+REVOKE ALL PRIVILEGES ON TABLE mutun FROM app_user;
+REVOKE ALL PRIVILEGES ON TABLE mutun_lines FROM app_user;
+REVOKE ALL PRIVILEGES ON TABLE scholars FROM app_user;
+REVOKE ALL PRIVILEGES ON TABLE prophets FROM app_user;
+REVOKE ALL PRIVILEGES ON TABLE islamic_calendar FROM app_user;
+REVOKE ALL PRIVILEGES ON TABLE reference_books FROM app_user;
+REVOKE ALL PRIVILEGES ON TABLE book_chapters FROM app_user;
+REVOKE ALL PRIVILEGES ON TABLE book_content FROM app_user;
+
+-- Accorder uniquement SELECT
+GRANT SELECT ON TABLE quran_surahs TO app_user;
+GRANT SELECT ON TABLE quran_ayahs TO app_user;
+GRANT SELECT ON TABLE quran_translations TO app_user;
+GRANT SELECT ON TABLE quran_tafsirs TO app_user;
+GRANT SELECT ON TABLE quran_word_by_word TO app_user;
+GRANT SELECT ON TABLE quran_tajweed_rules TO app_user;
+GRANT SELECT ON TABLE audio_recitations TO app_user;
+GRANT SELECT ON TABLE reciters TO app_user;
+GRANT SELECT ON TABLE hadith_collections TO app_user;
+GRANT SELECT ON TABLE hadiths TO app_user;
+GRANT SELECT ON TABLE hadith_translations TO app_user;
+GRANT SELECT ON TABLE hadith_gradings TO app_user;
+GRANT SELECT ON TABLE hadith_categories TO app_user;
+GRANT SELECT ON TABLE hadith_category_links TO app_user;
+GRANT SELECT ON TABLE dua_categories TO app_user;
+GRANT SELECT ON TABLE duas TO app_user;
+GRANT SELECT ON TABLE allah_names TO app_user;
+GRANT SELECT ON TABLE mutun_categories TO app_user;
+GRANT SELECT ON TABLE mutun FROM app_user;
+GRANT SELECT ON TABLE mutun_lines TO app_user;
+GRANT SELECT ON TABLE scholars TO app_user;
+GRANT SELECT ON TABLE prophets TO app_user;
+GRANT SELECT ON TABLE islamic_calendar TO app_user;
+GRANT SELECT ON TABLE reference_books TO app_user;
+GRANT SELECT ON TABLE book_chapters TO app_user;
+GRANT SELECT ON TABLE book_content TO app_user;
+
+-- ════════════════════════════════════════════════
+-- 🔓 ZONE APPLICATIVE — DROITS COMPLETS
+-- ════════════════════════════════════════════════
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE users TO app_user;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE user_settings TO app_user;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE user_bookmarks TO app_user;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE user_favorites TO app_user;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE user_notes TO app_user;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE user_reading_progress TO app_user;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE user_quran_memorization TO app_user;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE user_mutun_memorization TO app_user;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE user_streaks TO app_user;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE user_badges TO app_user;
+GRANT SELECT ON TABLE badges TO app_user;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE subscriptions TO app_user;
+GRANT SELECT, INSERT ON TABLE payments TO app_user;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE social_follows TO app_user;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE social_posts TO app_user;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE social_comments TO app_user;
+GRANT SELECT, INSERT, DELETE ON TABLE social_reactions TO app_user;
+GRANT SELECT, INSERT ON TABLE social_reports TO app_user;
+GRANT SELECT ON TABLE academy_courses TO app_user;
+GRANT SELECT ON TABLE academy_lessons TO app_user;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE academy_enrollments TO app_user;
+GRANT SELECT, INSERT, UPDATE ON TABLE academy_lesson_progress TO app_user;
+GRANT SELECT, INSERT ON TABLE academy_assignments TO app_user;
+
+-- ════════════════════════════════════════════════
+-- 🎬 ZONE MÉDIA — SELECT pour app_user
+-- ════════════════════════════════════════════════
+
+GRANT SELECT ON TABLE youtube_channels TO app_user;
+GRANT SELECT ON TABLE youtube_playlists TO app_user;
+GRANT SELECT ON TABLE youtube_videos TO app_user;
+GRANT SELECT ON TABLE translated_videos TO app_user;
+GRANT SELECT ON TABLE videos TO app_user;
+
+-- Séquences (nécessaires pour les SERIAL / auto-increment)
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO app_user;
+
+-- ════════════════════════════════════════════════
+-- AUDIT LOG — Toute tentative d'écriture sur zone sacrée
+-- ════════════════════════════════════════════════
+
+CREATE TABLE audit_sacred_zone (
+  id              BIGSERIAL PRIMARY KEY,
+  attempted_at    TIMESTAMPTZ DEFAULT NOW(),
+  table_name      TEXT NOT NULL,
+  operation       TEXT NOT NULL,                 -- INSERT, UPDATE, DELETE
+  attempted_by    TEXT DEFAULT current_user,
+  details         TEXT
+);
+
+-- Trigger sur quran_ayahs (exemple — à dupliquer sur chaque table sacrée)
+CREATE OR REPLACE FUNCTION fn_audit_sacred_zone()
+RETURNS TRIGGER AS $$
+BEGIN
+  INSERT INTO audit_sacred_zone (table_name, operation, details)
+  VALUES (TG_TABLE_NAME, TG_OP, 'Tentative bloquée — zone sacrée immuable');
+  RAISE EXCEPTION '🔒 INTERDIT — La table % est sacrée et immuable.', TG_TABLE_NAME;
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_protect_quran_ayahs
+  BEFORE INSERT OR UPDATE OR DELETE ON quran_ayahs
+  FOR EACH ROW EXECUTE FUNCTION fn_audit_sacred_zone();
+
+CREATE TRIGGER trg_protect_hadiths
+  BEFORE INSERT OR UPDATE OR DELETE ON hadiths
+  FOR EACH ROW EXECUTE FUNCTION fn_audit_sacred_zone();
+
+CREATE TRIGGER trg_protect_mutun_lines
+  BEFORE INSERT OR UPDATE OR DELETE ON mutun_lines
+  FOR EACH ROW EXECUTE FUNCTION fn_audit_sacred_zone();

--- a/docs/TASK_BOARD.md
+++ b/docs/TASK_BOARD.md
@@ -6,9 +6,7 @@
 
 ## 🔴 En cours
 
-| Tâche | Assigné à | Branche | Début | Statut |
-|---|---|---|---|---|
-| Initialisation du repo + structure | Moha | `dev/moha/init-repo` | 2026-02-24 | ✅ Terminé |
+*Rien en cours pour l'instant*
 
 ---
 
@@ -16,21 +14,21 @@
 
 | Tâche | Priorité | Notes |
 |---|---|---|
-| Schéma PostgreSQL — Zone sacrée (Coran, Hadiths, Duas) | 🔴 Haute | Définir toutes les tables avec permissions |
-| Schéma PostgreSQL — Zone applicative (users, progress...) | 🔴 Haute | Auth, favoris, progression |
-| Setup Next.js 14 de base | 🔴 Haute | App Router, TailwindCSS, polices islamiques |
-| Page lecture Coran (affichage sourates + versets) | 🔴 Haute | RTL, police KFGQPC, référence verset |
-| Intégration API AlQuran.cloud | 🔴 Haute | Données SACRÉES — lecture seule |
-| Page horaires de prière | 🟠 Moyenne | Aladhan API, méthode de calcul affichée |
-| Système d'authentification | 🟠 Moyenne | NextAuth.js |
+| Setup Next.js 14 de base | 🔴 Haute | App Router, TailwindCSS, polices islamiques (Amiri) |
+| Page lecture Coran (sourates + versets) | 🔴 Haute | RTL, police KFGQPC, référence verset, Bismillah |
+| Intégration API AlQuran.cloud | 🔴 Haute | Données SACRÉES — lecture seule uniquement |
+| Page horaires de prière | 🟠 Moyenne | Aladhan API, afficher la méthode de calcul |
+| Système d'authentification | 🟠 Moyenne | NextAuth.js — email + Google |
+| Lecteur audio récitations | 🟡 Basse | Intégrer avec quran-reader |
 
 ---
 
 ## 🟢 Terminé
 
-| Tâche | Par | Date | PR |
+| Tâche | Par | Date | PR / Branche |
 |---|---|---|---|
-| Setup repo GitHub (structure, docs, gitignore) | Moha | 2026-02-24 | — |
+| Setup repo GitHub (structure, docs) | Moha | 2026-02-24 | `dev/moha/init-repo` |
+| Schéma PostgreSQL complet (BDD) | Bilal | 2026-02-24 | `dev/bilal/schema-bdd` |
 
 ---
 

--- a/memory/2026-02-24-bilal.md
+++ b/memory/2026-02-24-bilal.md
@@ -1,0 +1,62 @@
+# 📅 Session du 2026-02-24 — Bilal
+
+## ✅ Ce qui a été fait
+
+- Première session de Bilal sur le projet
+- Repo passé en public (pour activer la protection de branche gratuite)
+- Protection de la branche `main` activée (review obligatoire avant merge)
+- Schéma complet de la base de données créé (9 fichiers SQL)
+
+## 🗄️ Schéma base de données créé
+
+- `000_create_database.sql` → Création BDD + extensions PostgreSQL
+- `001_sacred_zone_quran.sql` → Tables Coran (sourates, versets, traductions, tafsirs, tajweed, audio)
+- `002_sacred_zone_hadiths.sql` → Tables Hadiths (collections, textes, traductions, classifications)
+- `003_sacred_zone_islamic_sciences.sql` → Duas, Noms d'Allah, Mutun, Savants, Prophètes, Calendrier Hijri
+- `004_applicative_zone_users.sql` → Utilisateurs, paramètres, favoris, abonnements, paiements
+- `005_applicative_zone_progress.sql` → Progression Coran + Mutun, SRS, streaks, badges
+- `006_applicative_zone_social_academy.sql` → Social Halal + Académie islamique
+- `007_media_zone.sql` → Vidéos, YouTube, traductions automatiques
+- `008_permissions.sql` → Droits SQL (zone sacrée = SELECT only) + triggers d'audit
+
+## 🔧 Décisions techniques prises
+
+- Protection de la branche `main` activée via GitHub API
+- Repo rendu public (protection de branche gratuite sur GitHub Free)
+- Système d'audit sur les tables sacrées : trigger bloque et log toute tentative d'écriture
+- Badges islamiques initiaux insérés (Al-Fatiha, Juz Amma, streaks...)
+- Réactions sociales halal : MashAllah, BarakAllah, Ameen, JazakAllah (pas de "like" vide)
+
+## 📊 État actuel du projet
+
+- Repo GitHub : ✅ Public + main protégée
+- Documentation : ✅ Complète
+- Schéma BDD : ✅ 100% complet (zone sacrée + applicative + média + sécurité)
+- Code source (Next.js) : 0% — à démarrer
+
+## ⏭️ Prochaines étapes suggérées (prochaine session)
+
+1. Setup Next.js 14 avec TailwindCSS + polices islamiques (Amiri)
+2. Page d'accueil avec navigation vers les modules
+3. Lecteur Coran : affichage des sourates + versets en arabe (RTL)
+
+## 💬 Notes pour Moha
+
+- Schéma BDD complet créé sur `dev/bilal/schema-bdd` — pense à pull avant de toucher à la BDD
+- J'ai ajouté des triggers d'audit sur quran_ayahs, hadiths, mutun_lines (voir migration 008)
+- Question ouverte : qui setup Next.js — toi ou moi ? Je te laisse décider (TASK_BOARD)
+- Repo maintenant PUBLIC — vérifie que rien de sensible n'y figure
+
+## 📁 Fichiers créés / modifiés
+
+- `database/migrations/000_create_database.sql` → Nouveau
+- `database/migrations/001_sacred_zone_quran.sql` → Nouveau
+- `database/migrations/002_sacred_zone_hadiths.sql` → Nouveau
+- `database/migrations/003_sacred_zone_islamic_sciences.sql` → Nouveau
+- `database/migrations/004_applicative_zone_users.sql` → Nouveau
+- `database/migrations/005_applicative_zone_progress.sql` → Nouveau
+- `database/migrations/006_applicative_zone_social_academy.sql` → Nouveau
+- `database/migrations/007_media_zone.sql` → Nouveau
+- `database/migrations/008_permissions.sql` → Nouveau
+- `docs/TASK_BOARD.md` → Mis à jour
+- `memory/2026-02-24-bilal.md` → Ce fichier


### PR DESCRIPTION
## Ce qui a été fait

Schéma PostgreSQL complet de la plateforme islamique.

### Fichiers créés

| Fichier | Contenu |
|---|---|
| `000_create_database.sql` | Création BDD UTF-8 + extensions |
| `001_sacred_zone_quran.sql` | Tables Coran (sourates, versets, traductions, tafsirs, tajweed, audio) |
| `002_sacred_zone_hadiths.sql` | Tables Hadiths (collections, textes, traductions, classifications) |
| `003_sacred_zone_islamic_sciences.sql` | Duas, Noms d'Allah, Mutun, Savants, Prophètes, Calendrier Hijri |
| `004_applicative_zone_users.sql` | Utilisateurs, settings, favoris, abonnements |
| `005_applicative_zone_progress.sql` | SRS Coran + Mutun, streaks, badges islamiques |
| `006_applicative_zone_social_academy.sql` | Social Halal + Académie |
| `007_media_zone.sql` | Vidéos, YouTube, traductions auto |
| `008_permissions.sql` | Droits SQL + triggers d'audit zone sacrée |

### ⚠️ Checklist données religieuses

- [x] Aucun contenu religieux modifié
- [x] Zone sacrée = SELECT uniquement pour app_user (REVOKE + GRANT)
- [x] Triggers d'audit sur quran_ayahs, hadiths, mutun_lines
- [x] Aucun secret dans le code
- [x] Encodage UTF-8 obligatoire partout

**Pour Moha** : Pull avant de toucher à la BDD. J'ai ajouté des triggers d'audit sur les tables sacrées.